### PR TITLE
Compatability with modsync plugin

### DIFF
--- a/UnlimitedMages/UnlimitedMagesPlugin.cs
+++ b/UnlimitedMages/UnlimitedMagesPlugin.cs
@@ -23,6 +23,7 @@ namespace UnlimitedMages
         /// This value is accessed by various patches to dynamically adjust game logic and UI.
         /// </summary>
         public static ConfigEntry<int>? TeamSizeConfig;
+        public static string modsync = "all"; // Compatability with modsync plugin
 
         /// <summary>
         /// BepInEx entry point. Called once upon plugin loading.


### PR DESCRIPTION
Adding this string will allow users to police the lobby using modsync's automatic kicking when mods are mismatched.